### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ $ echo '[
   {
     "subject": "VULNERABILITY_ID",
     "operator": "IS",
-    "value": "CVE-2023-11111"
+    "value": "CVE-2014-123456"
   },
   {
     "subject": "VULNERABILITY_ID",
     "operator": "IS",
-    "value": "CVE-2023-22222"
+    "value": "CVE-2014-99999"
   }
 ]' | DT_API_KEY="..." dependency-track-policy-applier --policy-name myPolicy --policy-projects test:latest --policy-tags foo
 
@@ -32,13 +32,13 @@ $ echo '[
   {
     "subject": "VULNERABILITY_ID",
     "operator": "IS",
-    "value": "CVE-2023-11111"
+    "value": "CVE-2014-10000"
   }
 ]' | DT_API_KEY="..." dependency-track-policy-applier --policy-name myPolicy 
 
 2023/09/01 12:42:46 apply tags: remove tag "foo"
 2023/09/01 12:42:46 apply projects: remove project 451b427e-cd46-45f0-98eb-63705c4dc624
-2023/09/01 12:42:46 apply policyConditions: remove policyCondition: VULNERABILITY_ID IS "CVE-2023-22222"
+2023/09/01 12:42:46 apply policyConditions: remove policyCondition: VULNERABILITY_ID IS "CVE-2014-123456"
 ```
 
 
@@ -61,12 +61,12 @@ Permissions:
   {
     "subject": "VULNERABILITY_ID",
     "operator": "IS",
-    "value": "CVE-2023-11111"
+    "value": "CVE-2014-123456"
   },
   {
     "subject": "VULNERABILITY_ID",
     "operator": "IS",
-    "value": "CVE-2023-22222"
+    "value": "CVE-2014-99999"
   }
 ]
 ```


### PR DESCRIPTION
Change current fictional CVEs that could become valid ones but likely not. The new ones are official "use as example" CVE IDs, and the actual already published CVE IDs at the end were left alone..